### PR TITLE
Allow use as module

### DIFF
--- a/picard_parser/__init__.py
+++ b/picard_parser/__init__.py
@@ -1,0 +1,1 @@
+from .picard_parser import PicardParser


### PR DESCRIPTION
This change allows users to use this as a module: `from picard_parser import PicardParser` when used with a directory structure like `site-packages/picard_parser/picard_parser.py`.

Reference: https://timothybramlett.com/How_to_create_a_Python_Package_with___init__py.html